### PR TITLE
Setup OrgWarden Auto-Audit workflow

### DIFF
--- a/.github/workflows/OrgWarden.yml
+++ b/.github/workflows/OrgWarden.yml
@@ -1,0 +1,32 @@
+name: Auto Audit
+
+on:
+  schedule:
+    - cron: '14 0 * * *' # run daily at 10:00 am Eastern
+  workflow_dispatch: # enables manual trigger
+
+jobs:
+  Auto-Audit:
+    runs-on: ubuntu-latest
+    steps:
+        # Setup OrgWarden locally
+      - name: Checkout OrgWarden
+        uses: actions/checkout@v4
+        with:
+          repository: gt-tech-ai/OrgWarden
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Dependencies
+        run: uv sync --frozen
+
+        # Audit gt-tech-ai with OrgWarden
+        # See https://github.com/gt-tech-ai/OrgWarden for help setting up a PAT
+        # and configuring repository-specific audit settings
+      - name: Run OrgWarden Audit
+        run: |
+          uv run orgwarden audit https://github.com/gt-tech-ai \
+          --gh-pat ${{ secrets.ORG_WARDEN_AUDIT_PAT }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Added Orgwarden Auto-Audit workflow
- The `AUTO_AUDIT_PAT` fine-grained token secret is not yet setup - I don't appear to have the required permissions to add secrets for this repo