### PR TITLE
Enhancement: add OrgWarden-Notification.yml workflow - enables slack notifications only for failed OrgWarden runs

### DIFF
--- a/.github/workflows/OrgWarden-Notification.yml
+++ b/.github/workflows/OrgWarden-Notification.yml
@@ -1,0 +1,18 @@
+name: OrgWarden Failed
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-url:
+        type: string
+        description: URL of the failing OrgWarden run.
+        required: true
+
+jobs:
+  Trigger-Notification:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "OrgWarden Failed!"
+          echo "View workflow logs at ${{ inputs.run-url }}"
+          exit 1

--- a/.github/workflows/OrgWarden.yml
+++ b/.github/workflows/OrgWarden.yml
@@ -9,7 +9,21 @@ jobs:
   Run-OrgWarden:
     runs-on: ubuntu-latest
     steps:
-      - uses: gt-tech-ai/OrgWarden@action-v0
+      - name: Run OrgWarden
+        uses: gt-tech-ai/OrgWarden@action-v0
         with:
           org-url: https://github.com/gt-tech-ai
           github-pat: ${{ secrets.ORG_WARDEN_AUDIT_PAT }}
+
+      - name: Trigger Failure Notification
+        # If OrgWarden failed a scheduled run
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        # Send a work_dispatch event to OrgWarden-Notification.yml
+        run: |
+          gh api --method POST /repos/${{ github.repository }}/actions/workflows/OrgWarden-Notification.yml/dispatches \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -f "ref=main" \
+          -f "inputs[run-url]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Send Slack Notifications only for failed OrgWarden runs
Problem: The GitHub Slack bot does not allow you to filter your workflow subscriptions to include only failed runs. This creates unnecessary daily notifications for OrgWarden's successful runs.

I've created a new `OrgWarden-Notification.yml` workflow as a workaround. When the main OrgWarden workflow fails a scheduled run (not a manual rerun by team members that are checking if their changes fix audit errors), it will send a `workflow_dispatch` event to the `OrgWarden-Notification.yml` workflow.

In our Slack channel, we can subscribe to this notification workflow instead of the main OrgWarden workflow. This ensures that we receive notifications for failed OrgWarden audits, but prevents the clutter of notifications from successful runs.